### PR TITLE
Eliminate use of ITransport interface

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -1,5 +1,5 @@
 // Load the recipe
-#load nuget:?package=TestCentric.Cake.Recipe&version=1.1.0-dev00062
+#load nuget:?package=TestCentric.Cake.Recipe&version=1.1.0-dev00063
 // Comment out above line and uncomment below for local tests of recipe changes
 //#load ../TestCentric.Cake.Recipe/recipe/*.cake
 

--- a/nuget/TestCentric.Agent.Core.nuspec
+++ b/nuget/TestCentric.Agent.Core.nuspec
@@ -17,7 +17,7 @@
     <repository type="Git" url="https://github.com/TestCentric/TestCentric.Cake.Recipe" />
     <dependencies>
         <dependency id="TestCentric.InternalTrace" version="1.0.0" />
-        <dependency id="TestCentric.Engine.Core" version="2.0.0-dev00026" />
+        <dependency id="TestCentric.Engine.Core" version="2.0.0-dev00028" />
 	</dependencies>
   </metadata>
 	<files>

--- a/src/TestCentric.Agent.Core/Communication/Transports/ITestAgentTransport.cs
+++ b/src/TestCentric.Agent.Core/Communication/Transports/ITestAgentTransport.cs
@@ -7,9 +7,11 @@ using TestCentric.Engine.Agents;
 
 namespace TestCentric.Engine.Communication.Transports
 {
-    public interface ITestAgentTransport : ITransport
+    public interface ITestAgentTransport
     {
         TestAgent Agent { get; }
         ITestEngineRunner CreateRunner(TestPackage package);
+        bool Start();
+        void Stop();
     }
 }

--- a/src/TestCentric.Agent.Core/TestCentric.Agent.Core.csproj
+++ b/src/TestCentric.Agent.Core/TestCentric.Agent.Core.csproj
@@ -37,8 +37,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="TestCentric.Engine.Core" Version="2.0.0-dev00026" />
-		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00028" />
+		<PackageReference Include="TestCentric.Engine.Core" Version="2.0.0-dev00028" />
+		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00030" />
 		<PackageReference Include="TestCentric.Extensibility" Version="2.0.0" />
 		<PackageReference Include="TestCentric.Metadata" Version="2.0.0" />
 		<PackageReference Include="TestCentric.InternalTrace" Version="1.0.0" />

--- a/src/tests/TestCentric.Agent.Core.Tests.csproj
+++ b/src/tests/TestCentric.Agent.Core.Tests.csproj
@@ -28,7 +28,7 @@
 	<ItemGroup>
 		<PackageReference Include="NUnit" Version="3.12.0" />
 		<PackageReference Include="NUnitLite" Version="3.12.0" />
-		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00028" />
+		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00030" />
 		<PackageReference Include="TestCentric.Extensibility" Version="2.0.0" />
 	</ItemGroup>
 


### PR DESCRIPTION
ITransport interface no longer exists in Engine.Core. Modify ITestAgentTransport to include its two methods.