### PR TITLE
Move communications code from TestCentric.Engine.Core

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -24,8 +24,6 @@ BuildSettings.Packages.Add(new NuGetPackage(
 		HasDirectory("lib/netstandard2.0").WithFiles("TestCentric.Agent.Core.dll"),
 		HasDirectory("lib/netcoreapp3.1").WithFiles("TestCentric.Agent.Core.dll"),
 		HasDependency(PackageReference.InternalTrace),
-		HasDependency(new PackageReference("TestCentric.Engine.Core", "2.0.0-beta4"))
-		//HasDependency(PackageReference.EngineCore.LatestDevBuild)
 	}
 ));
 

--- a/nuget/TestCentric.Agent.Core.nuspec
+++ b/nuget/TestCentric.Agent.Core.nuspec
@@ -19,7 +19,6 @@
         <repository type="Git" url="https://github.com/TestCentric/TestCentric.Cake.Recipe" />
         <dependencies>
             <dependency id="TestCentric.InternalTrace" version="1.0.0" />
-            <dependency id="TestCentric.Engine.Core" version="2.0.0-beta4" />
 	    </dependencies>
     </metadata>
 	

--- a/src/TestCentric.Agent.Core/Communication/Protocols/BinarySerializationProtocol.cs
+++ b/src/TestCentric.Agent.Core/Communication/Protocols/BinarySerializationProtocol.cs
@@ -1,0 +1,236 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Text;
+using TestCentric.Engine.Communication.Messages;
+
+namespace TestCentric.Engine.Communication.Protocols
+{
+    /// <summary>
+    /// BinarySerializationProtocol serializes messages as an array of bytes in the following format:
+    ///
+    ///     <Message Length> <Message Code> [<Additional Message Data>]
+    ///
+    /// The length of the message is encoded as four bytes, from lowest to highest order.
+    /// 
+    /// The message code is always four bytes and indicates the type of message.
+    /// 
+    /// Messages taking an additional data argument encode it in the remaining bytes. The
+    /// argument length may therefore be calculated as overall length - 8 bytes. Messages
+    /// without an argument are serialized as 8 bytes.
+    /// </summary>
+    public class BinarySerializationProtocol : ISerializationProtocol
+    {
+        private const int MSG_LENGTH_SIZE = 4;
+        private const int MSG_CODE_SIZE = 4;
+
+        /// <summary>
+        /// Maximum length of a message.
+        /// </summary>
+        private const int MAX_MESSAGE_LENGTH = 128 * 1024 * 1024; //128 Megabytes.
+
+        /// <summary>
+        /// This MemoryStream object is used to collect receiving bytes to build messages.
+        /// </summary>
+        private MemoryStream _receiveMemoryStream = new MemoryStream();
+
+        /// <summary>
+        /// Serializes a message to a byte array to send to remote application.
+        /// </summary>
+        /// <param name="message">Message to be serialized</param>
+        /// <returns>A byte[] containing the message, serialized as per the protocol.</returns>
+        public byte[] Encode(TestEngineMessage message)
+        {
+            string code = message.Code;
+            string data = message.Data;
+            Encoding utf8 = Encoding.UTF8;
+
+            // TODO: Compile time check
+            if (utf8.GetByteCount(code) != MSG_CODE_SIZE)
+                throw new ArgumentException($"Invalid message code {code}");
+
+            int dataLength = message.Data != null ? utf8.GetByteCount(message.Data) : 0;
+            int messageLength = dataLength + MSG_CODE_SIZE;
+
+            //Check message length
+            if (messageLength > MAX_MESSAGE_LENGTH)
+                throw new Exception("Message is too big (" + messageLength + " bytes). Max allowed length is " + MAX_MESSAGE_LENGTH + " bytes.");
+
+            //Create a byte array including the length of the message (4 bytes) and serialized message content
+            var bytes = new byte[messageLength + MSG_LENGTH_SIZE];
+            WriteInt32(bytes, 0, messageLength);
+            utf8.GetBytes(code, 0, code.Length, bytes, MSG_LENGTH_SIZE);
+            if (dataLength > 0)
+                utf8.GetBytes(data, 0, data.Length, bytes, MSG_LENGTH_SIZE + MSG_CODE_SIZE);
+
+            return bytes;
+        }
+
+        /// <summary>
+        /// Accept an array of bytes and deserialize the messages that are found.
+        /// A single call may provide no messages, part of a message, a single
+        /// message or multiple messages. Unused bytes are saved for use as
+        /// further calls are made.
+        /// </summary>
+        /// <param name="receivedBytes">The byte array to be deserialized</param>
+        /// <returns>An enumeration of TestEngineMessages</returns>
+        public IEnumerable<TestEngineMessage> Decode(byte[] receivedBytes)
+        {
+            // Write all received bytes to the _receiveMemoryStream, which may
+            // already contain part of a message from a previous call.
+            _receiveMemoryStream.Write(receivedBytes, 0, receivedBytes.Length);
+
+            //Create a list to collect messages
+            var messages = new List<TestEngineMessage>();
+
+            //Read all available messages and add to messages collection
+            while (ReadSingleMessage(messages)) { }
+
+            return messages;
+        }
+
+        public void Reset()
+        {
+            if (_receiveMemoryStream.Length > 0)
+            {
+                _receiveMemoryStream = new MemoryStream();
+            }
+        }
+
+        /// <summary>
+        /// This method tries to read a single message and add to the messages collection. 
+        /// </summary>
+        /// <param name="messages">Messages collection to collect messages</param>
+        /// <returns>
+        /// Returns a boolean value indicates that if there is a need to re-call this method.
+        /// </returns>
+        /// <exception cref="CommunicationException">Throws CommunicationException if message is bigger than maximum allowed message length.</exception>
+        private bool ReadSingleMessage(ICollection<TestEngineMessage> messages)
+        {
+            //Go to the begining of the stream
+            _receiveMemoryStream.Position = 0;
+
+            //If stream has less than 4 bytes, that means we can not even read length of the message
+            //So, return false to wait more for bytes from remorte application.
+            if (_receiveMemoryStream.Length < MSG_LENGTH_SIZE)
+            {
+                return false;
+            }
+
+            //Read length of the message
+            var messageLength = ReadInt32(_receiveMemoryStream);
+            if (messageLength > MAX_MESSAGE_LENGTH)
+                throw new Exception("Message is too big (" + messageLength + " bytes). Max allowed length is " + MAX_MESSAGE_LENGTH + " bytes.");
+
+            //If message is zero-length (It must not be but good approach to check it)
+            if (messageLength == 0)
+            {
+                //if no more bytes, return immediately
+                if (_receiveMemoryStream.Length == MSG_LENGTH_SIZE)
+                {
+                    _receiveMemoryStream = new MemoryStream(); //Clear the stream
+                    return false;
+                }
+
+                //Create a new memory stream from current except first 4-bytes.
+                var bytes = _receiveMemoryStream.ToArray();
+                _receiveMemoryStream = new MemoryStream();
+                _receiveMemoryStream.Write(bytes, MSG_LENGTH_SIZE, bytes.Length - MSG_LENGTH_SIZE);
+                return true;
+            }
+
+            //If all bytes of the message is not received yet, return to wait more bytes
+            if (_receiveMemoryStream.Length < (MSG_LENGTH_SIZE + messageLength))
+            {
+                _receiveMemoryStream.Position = _receiveMemoryStream.Length;
+                return false;
+            }
+
+            //Read bytes of serialized message and deserialize it
+            var serializedMessageBytes = ReadByteArray(_receiveMemoryStream, messageLength);
+
+            Encoding utf8 = Encoding.UTF8;
+
+            string code = utf8.GetString(serializedMessageBytes, 0, MSG_CODE_SIZE);
+
+            string data = messageLength > MSG_CODE_SIZE
+                ? utf8.GetString(serializedMessageBytes, MSG_CODE_SIZE, messageLength - MSG_CODE_SIZE)
+                : null;
+
+            messages.Add(new TestEngineMessage(code, data));
+
+            //Read remaining bytes to an array
+            var remainingBytes = ReadByteArray(_receiveMemoryStream, (int)(_receiveMemoryStream.Length - (4 + messageLength)));
+
+            //Re-create the receive memory stream and write remaining bytes
+            _receiveMemoryStream = new MemoryStream();
+            _receiveMemoryStream.Write(remainingBytes, 0, remainingBytes.Length);
+
+            //Return true to re-call this method to try to read next message
+            return (remainingBytes.Length > MSG_LENGTH_SIZE);
+        }
+
+        /// <summary>
+        /// Writes a int value to a byte array from a starting index.
+        /// </summary>
+        /// <param name="buffer">Byte array to write int value</param>
+        /// <param name="startIndex">Start index of byte array to write</param>
+        /// <param name="number">An integer value to write</param>
+        private static void WriteInt32(byte[] buffer, int startIndex, int number)
+        {
+            buffer[startIndex] = (byte)((number >> 24) & 0xFF);
+            buffer[startIndex + 1] = (byte)((number >> 16) & 0xFF);
+            buffer[startIndex + 2] = (byte)((number >> 8) & 0xFF);
+            buffer[startIndex + 3] = (byte)((number) & 0xFF);
+        }
+
+        /// <summary>
+        /// Deserializes and returns a serialized integer.
+        /// </summary>
+        /// <returns>Deserialized integer</returns>
+        private static int ReadInt32(Stream stream)
+        {
+            var buffer = ReadByteArray(stream, 4);
+            return ReadInt32(buffer, 0);
+        }
+
+        private static int ReadInt32(byte[] buffer, int index)
+        {
+            return ((buffer[index] << 24) |
+                    (buffer[index + 1] << 16) |
+                    (buffer[index + 2] << 8) |
+                    (buffer[index + 3])
+                   );
+        }
+
+        /// <summary>
+        /// Reads a byte array with specified length.
+        /// </summary>
+        /// <param name="stream">Stream to read from</param>
+        /// <param name="length">Length of the byte array to read</param>
+        /// <returns>Read byte array</returns>
+        /// <exception cref="EndOfStreamException">Throws EndOfStreamException if can not read from stream.</exception>
+        private static byte[] ReadByteArray(Stream stream, int length)
+        {
+            var buffer = new byte[length];
+            var totalRead = 0;
+            while (totalRead < length)
+            {
+                var read = stream.Read(buffer, totalRead, length - totalRead);
+                if (read <= 0)
+                {
+                    throw new EndOfStreamException("Can not read from stream! Input stream is closed.");
+                }
+
+                totalRead += read;
+            }
+
+            return buffer;
+        }
+    }
+}

--- a/src/TestCentric.Agent.Core/Communication/Transports/Tcp/SocketReader.cs
+++ b/src/TestCentric.Agent.Core/Communication/Transports/Tcp/SocketReader.cs
@@ -1,0 +1,70 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.Net.Sockets;
+using System.Text;
+using TestCentric.Engine.Communication.Messages;
+using TestCentric.Engine.Communication.Protocols;
+
+namespace TestCentric.Engine.Communication.Transports.Tcp
+{
+    public class SocketReader
+    {
+        private const int BUFFER_SIZE = 1024;
+
+        private Socket _socket;
+        private ISerializationProtocol _wireProtocol;
+
+        private Queue<TestEngineMessage> _msgQueue;
+        private byte[] _buffer;
+
+        public SocketReader(Socket socket, ISerializationProtocol protocol)
+        {
+            _socket = socket;
+            _wireProtocol = protocol;
+
+            _msgQueue = new Queue<TestEngineMessage>();
+            _buffer = new byte[BUFFER_SIZE];
+        }
+
+        /// <summary>
+        /// Get the next TestEngineMessage to arrive
+        /// </summary>
+        /// <returns>The message</returns>
+        public TestEngineMessage GetNextMessage()
+        {
+            while (_msgQueue.Count == 0)
+            {
+                int n = _socket.Receive(_buffer);
+                var bytes = new byte[n];
+                Array.Copy(_buffer, 0, bytes, 0, n);
+                foreach (var message in _wireProtocol.Decode(bytes))
+                    _msgQueue.Enqueue(message);
+            }
+
+            return _msgQueue.Dequeue();
+        }
+
+        /// <summary>
+        /// Get the next message to arrive, which must be of the
+        /// specified message type.
+        /// </summary>
+        /// <typeparam name="TMessage">The expected message type</typeparam>
+        /// <returns>A message of type TMessage</returns>
+        /// <exception cref="InvalidOperationException">A message of a different type was received</exception>
+        public TMessage GetNextMessage<TMessage>() where TMessage : TestEngineMessage
+        {
+            var receivedMessage = GetNextMessage();
+            var expectedMessage = receivedMessage as TMessage;
+
+            if (expectedMessage == null)
+                throw new InvalidOperationException($"Expected a {typeof(TMessage)} but received a {receivedMessage.GetType()}");
+
+            return expectedMessage;
+        }
+    }
+}

--- a/src/TestCentric.Agent.Core/TestCentric.Agent.Core.csproj
+++ b/src/TestCentric.Agent.Core/TestCentric.Agent.Core.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
 	<PropertyGroup>
 		<RootNamespace>TestCentric.Agent</RootNamespace>
@@ -37,8 +37,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="TestCentric.Engine.Core" Version="2.0.0-dev00008" />
-		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-beta4" />
+		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00003" />
 		<PackageReference Include="TestCentric.Extensibility" Version="2.0.0" />
 		<PackageReference Include="TestCentric.Metadata" Version="2.0.0" />
 		<PackageReference Include="TestCentric.InternalTrace" Version="1.0.0" />

--- a/src/mock-assembly/mock-assembly.csproj
+++ b/src/mock-assembly/mock-assembly.csproj
@@ -17,6 +17,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit" Version="3.13.3" />
   </ItemGroup>
 </Project>

--- a/src/tests/AgentDirectRunnerTests.cs
+++ b/src/tests/AgentDirectRunnerTests.cs
@@ -14,7 +14,7 @@ namespace TestCentric.Agents
 {
     public class AgentDirectRunnerTests
     {
-        [Test]
+        [Test, Ignore("Exits NUnitLite - must run this in a separate process somehow")]
         public void RunAgentDirectly()
         {
             var options = new AgentOptions(MockAssembly.AssemblyPath);

--- a/src/tests/Communication/Messages/MessageTests.cs
+++ b/src/tests/Communication/Messages/MessageTests.cs
@@ -1,0 +1,84 @@
+﻿// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System.Collections.Generic;
+using NUnit.Framework;
+using TestCentric.Engine.Communication.Protocols;
+using TestCentric.Engine.TestUtilities;
+
+namespace TestCentric.Engine.Communication.Messages
+{
+    public class MessageTests
+    {
+        const string EMPTY_FILTER = "</filter>";
+        static readonly string TEST_PACKAGE = new TestPackage("mock-assembly.dll").ToXml();
+
+        private BinarySerializationProtocol _wireProtocol = new BinarySerializationProtocol();
+
+        static readonly TestCaseData[] MessageTestData = new TestCaseData[]
+        {
+            new TestCaseData(MessageCode.CreateRunner, TEST_PACKAGE),
+            new TestCaseData(MessageCode.LoadCommand, null),
+            new TestCaseData(MessageCode.ReloadCommand, null),
+            new TestCaseData(MessageCode.UnloadCommand, null),
+            new TestCaseData(MessageCode.ExploreCommand, EMPTY_FILTER),
+            new TestCaseData(MessageCode.CountCasesCommand, EMPTY_FILTER),
+            new TestCaseData(MessageCode.RunCommand, EMPTY_FILTER),
+            new TestCaseData(MessageCode.RunAsyncCommand, EMPTY_FILTER),
+            new TestCaseData(MessageCode.RequestStopCommand, null),
+            new TestCaseData(MessageCode.ForcedStopCommand, null)
+        };
+
+        [TestCaseSource(nameof(MessageTestData))]
+        public void CommandMessageConstructionTests(string commandName, string argument)
+        {
+            var cmd = new TestEngineMessage(commandName, argument);
+            Assert.That(cmd.Code, Is.EqualTo(commandName));
+            Assert.That(cmd.CommandName, Is.EqualTo(commandName));
+            Assert.That(cmd.Argument, Is.EqualTo(argument));
+        }
+
+        [TestCaseSource(nameof(MessageTestData))]
+        public void CommandMessageEncodingTests(string commandName, string argument)
+        {
+            var cmd = new TestEngineMessage(commandName, argument);
+
+            var bytes = _wireProtocol.Encode(cmd);
+            var messages = new List<TestEngineMessage>(_wireProtocol.Decode(bytes));
+            var decoded = messages[0];
+            Assert.That(decoded.Code, Is.EqualTo(commandName));
+            Assert.That(decoded.CommandName, Is.EqualTo(commandName));
+            Assert.That(decoded.Argument, Is.EqualTo(argument));
+        }
+
+        [Test]
+        public void ProgressMessageTest()
+        {
+            const string REPORT = "Progress report";
+            var msg = new TestEngineMessage(MessageCode.ProgressReport, REPORT);
+            Assert.That(msg.Code, Is.EqualTo(MessageCode.ProgressReport));
+            Assert.That(msg.Data, Is.EqualTo(REPORT));
+            var bytes = _wireProtocol.Encode(msg);
+            var messages = new List<TestEngineMessage>(_wireProtocol.Decode(bytes));
+            var decoded = messages[0];
+            Assert.That(decoded.Code, Is.EqualTo(MessageCode.ProgressReport));
+            Assert.That(decoded.Data, Is.EqualTo(REPORT));
+        }
+
+        [Test]
+        public void CommandReturnMessageTest()
+        {
+            const string RESULT = "Result text";
+            var msg = new TestEngineMessage(MessageCode.CommandResult, RESULT);
+            Assert.That(msg.Code, Is.EqualTo(MessageCode.CommandResult));
+            Assert.That(msg.Data, Is.EqualTo(RESULT));
+            var bytes = _wireProtocol.Encode(msg);
+            var messages = new List<TestEngineMessage>(_wireProtocol.Decode(bytes));
+            var decoded = messages[0];
+            Assert.That(decoded.Code, Is.EqualTo(MessageCode.CommandResult));
+            Assert.That(decoded.Data, Is.EqualTo(RESULT));
+        }
+    }
+}

--- a/src/tests/Communication/Protocols/BinarySerializationProtocolTests.cs
+++ b/src/tests/Communication/Protocols/BinarySerializationProtocolTests.cs
@@ -1,0 +1,159 @@
+// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Xml.Serialization;
+using NUnit.Framework;
+using TestCentric.Engine.Communication.Messages;
+using TestCentric.Engine.TestUtilities;
+
+namespace TestCentric.Engine.Communication.Protocols
+{
+    public class BinarySerializationProtocolTests
+    {
+        private BinarySerializationProtocol wireProtocol = new BinarySerializationProtocol();
+
+        [Test]
+        public void WriteAndReadBytes()
+        {
+            int SIZE = 1024;
+
+            var bytes = new byte[SIZE];
+            new Random().NextBytes(bytes);
+
+            var stream = new MemoryStream();
+            stream.Write(bytes, 0, SIZE);
+
+            Assert.That(stream.Length, Is.EqualTo(SIZE));
+            var copy = new byte[SIZE];
+
+            stream.Position = 0;
+            Assert.That(stream.Read(copy, 0, SIZE), Is.EqualTo(SIZE));
+
+            Assert.That(copy, Is.EqualTo(bytes));
+        }
+
+        [Test]
+        public void DecodeSingleMessage()
+        {
+            var originalPackage = new TestPackage("mock-assembly.dll", "notest-assembly.dll");
+            var originalMessage = new TestEngineMessage(MessageCode.CommandResult, originalPackage.ToXml());
+
+            var bytes = wireProtocol.Encode(originalMessage);
+            Console.WriteLine($"Serialized {bytes.Length} bytes.");
+
+            var messages = new List<TestEngineMessage>(wireProtocol.Decode(bytes));
+            Assert.That(messages.Count, Is.EqualTo(1));
+            var message = messages[0];
+
+            Assert.That(message.Code, Is.EqualTo(MessageCode.CommandResult));
+            Assert.That(message.Data, Is.EqualTo(originalPackage.ToXml()));
+            var newPackage = DeserializePackage(message.Data);
+            ComparePackages(newPackage, originalPackage);
+        }
+
+        [TestCase(1)]
+        [TestCase(2)]
+        [TestCase(5)]
+        public void DecodeSplitMessages(int numMessages)
+        {
+            const int SPLIT_SIZE = 1000;
+
+            var originalPackage = new TestPackage("mock-assembly.dll", "notest-assembly.dll");
+            var originalMessage = new TestEngineMessage(MessageCode.CommandResult, originalPackage.ToXml());
+
+            var msgBytes = wireProtocol.Encode(originalMessage);
+            var msgLength = msgBytes.Length;
+            var allBytes = new byte[msgLength * numMessages];
+            for (int i = 0; i < numMessages; i++)
+                Array.Copy(msgBytes, 0, allBytes, i * msgLength, msgLength);
+
+            Console.WriteLine($"Serialized {numMessages} messages in {allBytes.Length} bytes.");
+
+            var messages = new List<TestEngineMessage>();
+
+            for (int index = 0; index < allBytes.Length; index += SPLIT_SIZE)
+            {
+                var bytesToSend = Math.Min(allBytes.Length - index, SPLIT_SIZE);
+                var buffer = new byte[bytesToSend];
+                Array.Copy(allBytes, index, buffer, 0, bytesToSend);
+                messages.AddRange(wireProtocol.Decode(buffer));
+                Console.WriteLine($"Decoded {bytesToSend} bytes, message count is now {messages.Count}");
+                var expectedCount = (index + bytesToSend) / msgLength;
+                Assert.That(messages.Count, Is.EqualTo(expectedCount));
+            }
+
+            foreach (TestEngineMessage message in messages)
+            {
+                Assert.That(message.Code, Is.EqualTo(MessageCode.CommandResult));
+                var newPackage = DeserializePackage(message.Data);
+                ComparePackages(newPackage, originalPackage);
+            }
+        }
+
+        //[Test]
+        public void DecodeMultipleMessages()
+        {
+            var commands = new string[] { "CMD1", "CMD2", "CMD3", "CMD4", "CMD5", "CMD6" };
+
+            var stream = new MemoryStream();
+
+            foreach (var command in commands)
+            {
+                var buffer = wireProtocol.Encode(new TestEngineMessage(command, null));
+                stream.Write(buffer, 0, buffer.Length);
+            }
+
+            var received = new List<TestEngineMessage>(wireProtocol.Decode(stream.ToArray()));
+            Assert.That(received.Count, Is.EqualTo(commands.Length));
+
+            for (int i = 0; i < commands.Length; i++)
+                Assert.That(received[i].CommandName, Is.EqualTo(commands[i]));
+        }
+
+        //[Test]
+        public void WriteAndReadTestPackageAsXml()
+        {
+            var originalPackage = new TestPackage(new string[] { "mock-assembly.dll", "notest-assembly.dll" });
+
+            Stream stream = new MemoryStream();
+            var serializer = new System.Xml.Serialization.XmlSerializer(typeof(TestPackage));
+            serializer.Serialize(stream, originalPackage);
+            Console.WriteLine($"Serialized {stream.Length} bytes to memory stream.");
+
+            stream.Position = 0;
+            object newPackage = serializer.Deserialize(stream);
+
+            Assert.That(newPackage, Is.TypeOf<TestPackage>());
+            ComparePackages((TestPackage)newPackage, originalPackage);
+        }
+
+        private TestPackage DeserializePackage(string xml)
+        {
+            var reader = new StringReader(xml);
+            var serializer = new XmlSerializer(typeof(TestPackage));
+            return serializer.Deserialize(reader) as TestPackage;
+        }
+
+        private void ComparePackages(TestPackage newPackage, TestPackage oldPackage)
+        {
+            Assert.That(newPackage.Name, Is.EqualTo(oldPackage.Name));
+            Assert.That(newPackage.FullName, Is.EqualTo(oldPackage.FullName));
+            Assert.That(newPackage.Settings.Count, Is.EqualTo(oldPackage.Settings.Count));
+            Assert.That(newPackage.SubPackages.Count, Is.EqualTo(oldPackage.SubPackages.Count));
+
+            foreach (var key in oldPackage.Settings.Keys)
+            {
+                Assert.That(newPackage.Settings.ContainsKey(key));
+                Assert.That(newPackage.Settings[key], Is.EqualTo(oldPackage.Settings[key]));
+            }
+
+            for (int i = 0; i < oldPackage.SubPackages.Count; i++)
+                ComparePackages(newPackage.SubPackages[i], oldPackage.SubPackages[i]);
+        }
+    }
+}

--- a/src/tests/TestCentric.Agent.Core.Tests.csproj
+++ b/src/tests/TestCentric.Agent.Core.Tests.csproj
@@ -26,9 +26,9 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="NUnit" Version="3.12.0" />
-		<PackageReference Include="NUnitLite" Version="3.12.0" />
-		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-beta4" />
+		<PackageReference Include="NUnit" Version="3.13.3" />
+		<PackageReference Include="NUnitLite" Version="3.13.3" />
+		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00003" />
 		<PackageReference Include="TestCentric.Extensibility" Version="2.0.0" />
 	</ItemGroup>
 

--- a/src/tests/TestUtilities/TestPackageExtensions.cs
+++ b/src/tests/TestUtilities/TestPackageExtensions.cs
@@ -1,0 +1,30 @@
+﻿// ***********************************************************************
+// Copyright (c) Charlie Poole and TestCentric contributors.
+// Licensed under the MIT License. See LICENSE file in root directory.
+// ***********************************************************************
+
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Serialization;
+
+namespace TestCentric.Engine.TestUtilities
+{
+    public static class TestPackageExtensions
+    {
+        public static string ToXml(this TestPackage package)
+        {
+            var writer = new StringWriter();
+            var xmlWriter = XmlWriter.Create(writer, new XmlWriterSettings() { OmitXmlDeclaration = true });
+            var serializer = new XmlSerializer(typeof(TestPackage));
+            serializer.Serialize(xmlWriter, package);
+            xmlWriter.Flush();
+            xmlWriter.Close();
+
+            return writer.ToString();
+        }
+    }
+}


### PR DESCRIPTION
Fixes #29 