### PR TITLE
Unload AssemblyLoadContext to avoid assembly blocking

### DIFF
--- a/src/TestCentric.Agent.Core/Resolvers/TestAssemblyLoadContext.cs
+++ b/src/TestCentric.Agent.Core/Resolvers/TestAssemblyLoadContext.cs
@@ -23,6 +23,7 @@ namespace TestCentric.Engine.Internal
         public TestAssemblyResolver Resolver { get; }
 
         public TestAssemblyLoadContext(string testAssemblyPath)
+            : base(isCollectible: true)
         {
             _testAssemblyPath = testAssemblyPath;
             _basePath = Path.GetDirectoryName(testAssemblyPath);

--- a/src/TestCentric.Agent.Core/Runners/TestAgentRunner.cs
+++ b/src/TestCentric.Agent.Core/Runners/TestAgentRunner.cs
@@ -158,6 +158,11 @@ namespace TestCentric.Engine.Runners
             {
                 throw new EngineException("An exception occurred in the driver while exploring tests.", ex);
             }
+            finally
+            {
+                RunGarbageCollector();
+            }
+
         }
 
         /// <summary>
@@ -177,6 +182,10 @@ namespace TestCentric.Engine.Runners
             catch (Exception ex) when (!(ex is EngineException))
             {
                 throw new EngineException("An exception occurred in the driver while counting test cases.", ex);
+            }
+            finally
+            {
+                RunGarbageCollector();
             }
         }
 
@@ -274,6 +283,10 @@ namespace TestCentric.Engine.Runners
                     log.Debug("An exception occurred in the driver while running tests.", ex);
                     throw new EngineException("An exception occurred in the driver while running tests.", ex);
                 }
+                finally
+                {
+                    RunGarbageCollector();
+                }
 
             if (_assemblyResolver != null)
                 _assemblyResolver.RemovePathFromFile(TestPackage.FullName);
@@ -303,6 +316,18 @@ namespace TestCentric.Engine.Runners
                     Unload();
 
                 _disposed = true;
+            }
+        }
+
+        /// <summary>
+        /// This garbage collector call is required for the unloading of a AssemblyLoadContext
+        /// </summary>
+        private static void RunGarbageCollector()
+        {
+            for (int i = 0; i < 10; i++)
+            {
+                GC.Collect();
+                GC.WaitForPendingFinalizers();
             }
         }
     }


### PR DESCRIPTION
This PR resolves #56  by unloading the `AssemblyLoadContext` and thereby not blocking the assembly anymore.

The intention was to keep the code changes to a minimum in order to improve the overview. But it might be worth to consider further development. So, this proposal might not be the final solution.

I used this description from Microsoft as a source for the know-how:
[Unloadability is .Net Core](https://learn.microsoft.com/en-us/dotnet/standard/assembly/unloadability)
From this description I see no other option than: we need to create+init an `AssemblyLoadContext` for every NUnit operation individually and afterwards unload it again. This means, for example that for the NUnit 'Explore' operation the `AssemblyLoadContext` is created and unloaded afterwards. And when starting the Nunit 'Run' operation the `AssemblyLoadContext` is created+init again!
That's in contrast to the current approach which creates+init the `AssemblyLoadContext` only once - but never unloads.

The code changes includes all aspects to unload an AssemblyLoadContext reliable as described in the Microsoft documents:
- Invoke `AssemblyLoadContext.Unload()` call and clear all references to assemby/types
- For all NUnit Actions: Explore, CountTestCases and Run first load and afterwards unload the AssemblyLoadContext
- Invoke garbage collector, because the unload is not performed right away by the .Net framwork

Using these changes I was able to compile a test assembly allthough it was loaded in TestCentric.