### PR TITLE
NUnit3FrameworkDriver load assembly into AppDomain (without blocking test assembly)

### DIFF
--- a/src/TestCentric.Agent.Core.Tests/Drivers/NUnit3FrameworkDriverTests.cs
+++ b/src/TestCentric.Agent.Core.Tests/Drivers/NUnit3FrameworkDriverTests.cs
@@ -4,14 +4,12 @@
 // ***********************************************************************
 
 #if NETFRAMEWORK
+using NUnit.Framework;
 using System;
 using System.Collections.Generic;
 using System.Xml;
-using TestCentric.Engine.Extensibility;
 using TestCentric.Engine.Internal;
 using TestCentric.Tests.Assemblies;
-using NUnit.Framework;
-using System.Reflection;
 
 namespace TestCentric.Engine.Drivers
 {
@@ -29,8 +27,9 @@ namespace TestCentric.Engine.Drivers
         [SetUp]
         public void CreateDriver()
         {
+            var assemblyName = typeof(NUnit.Framework.TestAttribute).Assembly.GetName();
             _mockAssemblyPath = System.IO.Path.Combine(TestContext.CurrentContext.TestDirectory, MOCK_ASSEMBLY);
-            _driver = new NUnit3FrameworkDriver();
+            _driver = new NUnit3FrameworkDriver(AppDomain.CurrentDomain, assemblyName);
         }
 
         [Test]
@@ -118,10 +117,7 @@ namespace TestCentric.Engine.Drivers
 
             var invalidFilter = "<filter><invalidElement>foo</invalidElement></filter>";
             var ex = Assert.Catch(() => _driver.Run(new NullListener(), invalidFilter));
-
-            // TODO: We should be getting an engine exception here
-            Assert.That(ex , Is.TypeOf<TargetInvocationException>());
-            //Assert.That(ex , Is.TypeOf<EngineException>());
+            Assert.That(ex , Is.TypeOf<EngineException>());
         }
 
         private static string GetSkipReason(XmlNode result)

--- a/src/TestCentric.Agent.Core/Drivers/NUnit3DriverFactory.cs
+++ b/src/TestCentric.Agent.Core/Drivers/NUnit3DriverFactory.cs
@@ -38,7 +38,7 @@ namespace TestCentric.Engine.Drivers
         {
             Guard.ArgumentValid(IsSupportedTestFramework(reference), "Invalid framework", "reference");
 
-            return new NUnit3FrameworkDriver();
+            return new NUnit3FrameworkDriver(domain, reference);
         }
 #else
         /// <summary>


### PR DESCRIPTION
This PR resolves #55 by rolling back commit [Changes to NUnit3Driver](https://github.com/TestCentric/TestCentric.Agent.Core/commit/305a85b0de274076c3be72f30b3dd70d6ad727bc#diff-11a9180fa6341b2712d863f590b13a64f47e79b1fd41a7de6bba743faa037ded).

The `NUnit3FrameworkDriver` uses an AppDomain to load the test assembly. If the AppDomain option 'ShadowCopy' is enabled the test assembly is not blocked by the TestCentric agent anymore and thus the test assembly can be modified, compiled and reloaded automatically into TestCentric.

Overall, the intention of this PR is not to introduce new concepts or approaches, but just enabling the existing concepts by adding the missing pieces. So, for example, the AppDomain creation, the 'ShadowCopy' option  and unloading were all already in place - the AppDomain was simply not used to load the test assembly anymore.