### PR TITLE
Update to use latest engine api version

### DIFF
--- a/src/DirectTestAgent/DirectTestAgent.csproj
+++ b/src/DirectTestAgent/DirectTestAgent.csproj
@@ -14,7 +14,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-beta7" />
+		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00005" />
 		<PackageReference Include="TestCentric.Extensibility" Version="3.1.0" />
 		<PackageReference Include="TestCentric.InternalTrace" Version="1.2.1" />
 	</ItemGroup>

--- a/src/TestCentric.Agent.Core.Tests/Communication/Protocols/BinarySerializationProtocolTests.cs
+++ b/src/TestCentric.Agent.Core.Tests/Communication/Protocols/BinarySerializationProtocolTests.cs
@@ -146,10 +146,11 @@ namespace TestCentric.Engine.Communication.Protocols
             Assert.That(newPackage.Settings.Count, Is.EqualTo(oldPackage.Settings.Count));
             Assert.That(newPackage.SubPackages.Count, Is.EqualTo(oldPackage.SubPackages.Count));
 
-            foreach (var key in oldPackage.Settings.Keys)
+            foreach (var setting in oldPackage.Settings)
             {
-                Assert.That(newPackage.Settings.ContainsKey(key));
-                Assert.That(newPackage.Settings[key], Is.EqualTo(oldPackage.Settings[key]));
+                Assert.That(newPackage.Settings.HasSetting(setting.Name));
+                Assert.That(newPackage.Settings.GetSetting(setting.Name),
+                    Is.EqualTo(oldPackage.Settings.GetSetting(setting.Name)));
             }
 
             for (int i = 0; i < oldPackage.SubPackages.Count; i++)

--- a/src/TestCentric.Agent.Core.Tests/Internal/DomainManagerStaticTests.cs
+++ b/src/TestCentric.Agent.Core.Tests/Internal/DomainManagerStaticTests.cs
@@ -8,6 +8,8 @@ using System;
 using System.Collections.Generic;
 using System.Configuration;
 using System.IO;
+using System.Linq;
+using NUnit.Common;
 using NUnit.Framework;
 
 namespace TestCentric.Engine.Internal
@@ -97,7 +99,7 @@ namespace TestCentric.Engine.Internal
 
             var package = new TestPackage(filePath);
             if (appBase != null)
-                package.Settings["BasePath"] = appBase;
+                package.Settings.Add(SettingDefinitions.BasePath.WithValue(appBase));
 
             Assert.That(DomainManager.GetApplicationBase(package), Is.SamePath(expected));
         }
@@ -110,7 +112,7 @@ namespace TestCentric.Engine.Internal
             appBase = TestPath(appBase);
             expected = TestPath(expected);
 
-            var package = new TestPackage(filePath);
+            var package = new TestPackage(filePath).SubPackages.First();
 
             Assert.That(DomainManager.GetPrivateBinPath(appBase, package), Is.EqualTo(expected));
         }
@@ -128,7 +130,7 @@ namespace TestCentric.Engine.Internal
 
             var package = new TestPackage(filePath);
             if (configSetting != null)
-                package.Settings["ConfigurationFile"] = configSetting;
+                package.Settings.Add(SettingDefinitions.ConfigurationFile.WithValue(configSetting));
 
             Assert.That(DomainManager.GetConfigFile(appBase, package), Is.EqualTo(expected));
         }
@@ -140,7 +142,7 @@ namespace TestCentric.Engine.Internal
         /// </summary>
         private static string TestPath(string path)
         {
-            if (path != null && Path.DirectorySeparatorChar != '/')
+            if (!string.IsNullOrEmpty(path) && Path.DirectorySeparatorChar != '/')
             {
                 path = path.Replace('/', Path.DirectorySeparatorChar);
                 if (path[0] == Path.DirectorySeparatorChar)

--- a/src/TestCentric.Agent.Core.Tests/Internal/DomainManagerTests.cs
+++ b/src/TestCentric.Agent.Core.Tests/Internal/DomainManagerTests.cs
@@ -6,6 +6,7 @@
 #if NETFRAMEWORK
 using System;
 using System.IO;
+using NUnit.Common;
 using NUnit.Framework;
 using TestCentric.Tests.Assemblies;
 
@@ -49,7 +50,7 @@ namespace TestCentric.Engine.Internal
             string basePath = Path.GetDirectoryName(Path.GetDirectoryName(assemblyDir));
             string relPath = assemblyDir.Substring(basePath.Length + 1);
 
-            _package.Settings["BasePath"] = basePath;
+            _package.Settings.Add(SettingDefinitions.BasePath.WithValue(basePath));
             var domain = _domainManager.CreateDomain(_package);
 
             Assert.That(domain, Is.Not.Null);

--- a/src/TestCentric.Agent.Core.Tests/TestCentric.Agent.Core.Tests.csproj
+++ b/src/TestCentric.Agent.Core.Tests/TestCentric.Agent.Core.Tests.csproj
@@ -38,7 +38,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-beta7" />
+		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00005" />
 		<PackageReference Include="TestCentric.Extensibility" Version="3.1.0" />
 	</ItemGroup>
 

--- a/src/TestCentric.Agent.Core/Communication/Transports/Tcp/TestAgentTcpTransport.cs
+++ b/src/TestCentric.Agent.Core/Communication/Transports/Tcp/TestAgentTcpTransport.cs
@@ -82,8 +82,8 @@ namespace TestCentric.Engine.Communication.Transports.Tcp
             log.Debug($"  Name={package.Name}");
             log.Debug($"  FullName={package.FullName}");
             log.Debug("  Settings:");
-            foreach(var key in package.Settings.Keys)
-                log.Debug($"    {key}={package.Settings[key]}");
+            foreach(var setting in package.Settings)
+                log.Debug($"    {setting.Name}={setting.Value}");
 
             return Agent.CreateRunner(package);
         }

--- a/src/TestCentric.Agent.Core/Runners/TestAgentRunner.cs
+++ b/src/TestCentric.Agent.Core/Runners/TestAgentRunner.cs
@@ -8,6 +8,8 @@ using TestCentric.Engine.Drivers;
 using TestCentric.Engine.Internal;
 using TestCentric.Engine.Extensibility;
 using System.ComponentModel;
+using NUnit.Common;
+using System.Collections.Generic;
 
 namespace TestCentric.Engine.Runners
 {
@@ -84,15 +86,15 @@ namespace TestCentric.Engine.Runners
             var testFile = TestPackage.FullName;
             log.Info($"Loading package {testFile}");
 
-            string targetFramework = TestPackage.GetSetting(EnginePackageSettings.ImageTargetFrameworkName, (string)null);
-            string frameworkReference = TestPackage.GetSetting(EnginePackageSettings.ImageTestFrameworkReference, (string)null);
-            bool skipNonTestAssemblies = TestPackage.GetSetting(EnginePackageSettings.SkipNonTestAssemblies, false);
+            string targetFramework = TestPackage.Settings.GetValueOrDefault(SettingDefinitions.ImageTargetFrameworkName);
+            string frameworkReference = TestPackage.Settings.GetValueOrDefault(SettingDefinitions.ImageTestFrameworkReference);
+            bool skipNonTestAssemblies = TestPackage.Settings.GetValueOrDefault(SettingDefinitions.SkipNonTestAssemblies);
 
             if (DriverService == null)
                 DriverService = new DriverService();
 
             if (_assemblyResolver != null && !TestDomain.IsDefaultAppDomain()
-                && TestPackage.GetSetting(EnginePackageSettings.ImageRequiresDefaultAppDomainAssemblyResolver, false))
+                && TestPackage.Settings.GetValueOrDefault(SettingDefinitions.ImageRequiresDefaultAppDomainAssemblyResolver))
             {
                 // It's OK to do this in the loop because the Add method
                 // checks to see if the path is already present.
@@ -102,12 +104,15 @@ namespace TestCentric.Engine.Runners
             log.Debug("Getting agent from DriverService");
             _driver = DriverService.GetDriver(TestDomain, testFile, targetFramework, skipNonTestAssemblies);
             _driver.ID = TestPackage.ID;
-
             log.Debug($"Using driver {_driver.GetType().Name}");
+
+            var frameworkSettings = new Dictionary<string, object>();
+            foreach (var setting in TestPackage.Settings)
+                frameworkSettings.Add(setting.Name, setting.Value);
 
             try
             {
-                return LoadResult = new TestEngineResult(_driver.Load(testFile, TestPackage.Settings));
+                return LoadResult = new TestEngineResult(_driver.Load(testFile, frameworkSettings));
             }
             catch (Exception ex) when (!(ex is EngineException))
             {

--- a/src/TestCentric.Agent.Core/TestCentric.Agent.Core.csproj
+++ b/src/TestCentric.Agent.Core/TestCentric.Agent.Core.csproj
@@ -44,7 +44,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-beta7" />
+		<PackageReference Include="TestCentric.Engine.Api" Version="2.0.0-dev00005" />
 		<PackageReference Include="TestCentric.Extensibility" Version="3.1.0" />
 		<PackageReference Include="TestCentric.Metadata" Version="3.0.4" />
 		<PackageReference Include="TestCentric.InternalTrace" Version="1.2.1" />


### PR DESCRIPTION
This updates `TestCentric.Agent.Core` to use the latest version of `TestCentric.Engine.Api`, 2.0.0-dev00005.

The handling of package settings is now entirely changed in the API. There are a number of new classes and the `TestPackage` class itself has been updated.

Ideally, those API changes would have been reviewed in a PR but I found that I had to make them incrementally, merging each stage as I went so they are already in the codebase.

@rowo360 Feel free to comment on the API changes themselves as well as the usage of it by `TestCentric.Agent.Core`.